### PR TITLE
Read client secret at runtime

### DIFF
--- a/common/dataplatform.py
+++ b/common/dataplatform.py
@@ -1,5 +1,8 @@
 import logging
+from functools import cache
 
+from okdata.aws.ssm import get_secret
+from okdata.sdk.config import Config
 from okdata.sdk.data.dataset import Dataset
 from okdata.sdk.data.upload import Upload
 from requests.exceptions import HTTPError
@@ -7,11 +10,21 @@ from requests.exceptions import HTTPError
 logger = logging.getLogger()
 
 
+@cache
+def _sdk_config():
+    sdk_config = Config()
+    sdk_config.config["client_secret"] = get_secret(
+        "/dataplatform/okdata-data-collectors/keycloak-client-secret"
+    )
+    return sdk_config
+
+
 def upload_dataset(dataset_id, filename):
     logger.info(f"Uploading dataset, id={dataset_id}, file={filename}")
 
-    dataset = Dataset()
-    upload = Upload()
+    sdk_config = _sdk_config()
+    dataset = Dataset(sdk_config)
+    upload = Upload(sdk_config)
 
     try:
         version = dataset.get_latest_version(dataset_id)["version"]

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -32,7 +32,6 @@ provider:
     SERVICE_NAME: ${self:service}
     OKDATA_ENVIRONMENT: ${self:custom.okdataEnvironment.${self:provider.stage}, self:custom.okdataEnvironment.dev}
     OKDATA_CLIENT_ID: ${self:service}
-    OKDATA_CLIENT_SECRET: ${ssm:/dataplatform/okdata-data-collectors/keycloak-client-secret}
 
 package:
   patterns:


### PR DESCRIPTION
Read the Keycloak client secret from SSM at runtime instead of having it in the Lambda environment.