### PR TITLE
Rename/remove some Agresso columns

### DIFF
--- a/agresso/service_helpers.py
+++ b/agresso/service_helpers.py
@@ -45,3 +45,28 @@ def simple_enricher(from_field, to_field, transformer):
         return row
 
     return _transformer
+
+
+def rename_columns(results, name_map):
+    """Rename the keys of every dict in `results` according to `name_map`.
+
+    `name_map` should be a dict on the form:
+    {
+      "new_name_1": "old_name_1",
+      "new_name_2": "old_name_2",
+      ...
+    }
+    """
+    for res in results:
+        for to_name, from_name in name_map.items():
+            res[to_name] = res[from_name]
+            del res[from_name]
+    return results
+
+
+def remove_columns(results, columns):
+    """Remove every key in `columns` from every dict in `results`"""
+    for res in results:
+        for col in columns:
+            del res[col]
+    return results

--- a/test/agresso/test_service_helpers.py
+++ b/test/agresso/test_service_helpers.py
@@ -3,6 +3,8 @@ from agresso.service_helpers import (
     _matches_filter,
     enrich_results,
     filter_results,
+    remove_columns,
+    rename_columns,
     simple_enricher,
 )
 
@@ -37,3 +39,27 @@ def test_simple_enricher():
     e = simple_enricher("a", "b", lambda x: x + "y")
     assert e({"a": "", "c": "x"}) == {"a": "", "b": "", "c": "x"}
     assert e({"a": "x"}) == {"a": "x", "b": "xy"}
+
+
+def test_rename_columns():
+    assert rename_columns([], {}) == []
+    assert rename_columns([], {"aa": "a"}) == []
+    assert rename_columns([{"a": 1, "b": 2}, {"a": 3, "b": 4}], {}) == [
+        {"a": 1, "b": 2},
+        {"a": 3, "b": 4},
+    ]
+    assert rename_columns(
+        [{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}], {"aa": "a", "bb": "b"}
+    ) == [{"aa": 1, "bb": 2, "c": 3}, {"aa": 4, "bb": 5, "c": 6}]
+
+
+def test_remove_columns():
+    assert remove_columns([], {}) == []
+    assert remove_columns([], ["a"]) == []
+    assert remove_columns([{"a": 1, "b": 2}, {"a": 3, "b": 4}], {}) == [
+        {"a": 1, "b": 2},
+        {"a": 3, "b": 4},
+    ]
+    assert remove_columns(
+        [{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}], ["a", "b"]
+    ) == [{"c": 3}, {"c": 6}]


### PR DESCRIPTION
Do the renaming and removal of columns from the Agresso datasets here instead of in the pipeline. The old JSON->CSV pipeline with JSLT support is dropped in favor of a simpler pure JSON->Delta pipeline.